### PR TITLE
Add stat.gov.pl to the whitelist

### DIFF
--- a/domains/whitelist.txt
+++ b/domains/whitelist.txt
@@ -189,3 +189,4 @@ continuum.dds.microsoft.com
 connectivitycheck.gstatic.com
 connectivitycheck.android.com
 www.msftconnecttest.com
+stat.gov.pl


### PR DESCRIPTION

Hi!

I've noticed that the filters are catching false positive on https://stat.gov.pl/ – the website of Statistics Poland

Added it to the whitelist

Cheers